### PR TITLE
Complete Proper Help Command Integration

### DIFF
--- a/src/main/java/com/arcaneminecraft/server/Alert.java
+++ b/src/main/java/com/arcaneminecraft/server/Alert.java
@@ -1,0 +1,64 @@
+package com.arcaneminecraft.server;
+
+import org.bukkit.Material;
+import org.bukkit.block.Biome;
+import org.bukkit.block.Block;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.SignChangeEvent;
+
+import java.util.HashMap;
+
+public class Alert implements Listener {
+    private final ArcaneServer plugin;
+    private final HashMap<Material, XRayCheck> xrayList;
+
+    Alert(ArcaneServer plugin) {
+        this.plugin = plugin;
+
+        this.xrayList = new HashMap<>();
+        ConfigurationSection cs = plugin.getConfig().getConfigurationSection("spy.xray-blocks");
+
+        // TODO: Check for null cs
+
+        for (String key : cs.getKeys(false))
+            new XRayCheck(cs.getConfigurationSection(key));
+    }
+
+    private final class XRayCheck {
+        private final int yMax;
+        private final int yMin;
+        private final Biome biome;
+
+        private XRayCheck(ConfigurationSection cs) {
+            this.yMax = cs.getInt("y-max", 256);
+            this.yMin = cs.getInt("y-min", 0);
+            String csBiome = cs.getString("biome"); // TODO: Define many biomes?
+            this.biome = csBiome == null ? null : Biome.valueOf(csBiome.toUpperCase());
+
+            // cs.getName() (item name) must be all uppercase for some reason
+            xrayList.put(Material.getMaterial(cs.getName().toUpperCase()), this);
+        }
+
+        private boolean toLog(Block b) {
+            return (biome == null || biome.equals(b.getBiome())) && b.getY() <= yMax && b.getY() >= yMin;
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onOreMined(BlockBreakEvent e) {
+        XRayCheck check = xrayList.get(e.getBlock().getType());
+
+        if (check != null && check.toLog(e.getBlock())) {
+            plugin.getPluginMessenger().xRayAlert(e.getPlayer(), e.getBlock());
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onSign(SignChangeEvent e) {
+        plugin.getPluginMessenger().signAlert(e.getPlayer(), e.getBlock(), e.getLines());
+    }
+}

--- a/src/main/java/com/arcaneminecraft/server/ArcAFK.java
+++ b/src/main/java/com/arcaneminecraft/server/ArcAFK.java
@@ -1,25 +1,23 @@
 package com.arcaneminecraft.server;
 
-import java.util.HashMap;
-import java.util.Iterator;
-
 import com.arcaneminecraft.api.ArcaneText;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.AsyncPlayerChatEvent;
-import org.bukkit.event.player.PlayerCommandPreprocessEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerMoveEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.*;
 import org.bukkit.scheduler.BukkitRunnable;
 
-final class ArcAFK implements CommandExecutor, Listener {
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+
+final class ArcAFK implements TabExecutor, Listener {
     private final ArcaneServer plugin;
     private final HashMap<Player, Integer> afkCounter = new HashMap<>();
     private static final int AFK_COUNTDOWN = 10; // 10 rounds (this * AFK_CHECK = 5 minute) countdown to being afk
@@ -71,6 +69,11 @@ final class ArcAFK implements CommandExecutor, Listener {
         afkCounter.remove(p);
 
         return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        return Collections.emptyList();
     }
 
     private boolean isAFK(Player p) {

--- a/src/main/java/com/arcaneminecraft/server/ArcaneServer.java
+++ b/src/main/java/com/arcaneminecraft/server/ArcaneServer.java
@@ -21,9 +21,16 @@ public final class ArcaneServer extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        saveDefaultConfig();
+
         pluginMessenger = new PluginMessenger(this);
         getServer().getMessenger().registerIncomingPluginChannel(this, "BungeeCord", pluginMessenger);
         getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
+
+        // X-Ray notification Logging
+        getServer().getMessenger().registerOutgoingPluginChannel(this, "ArcaneAlert");
+        getServer().getPluginManager().registerEvents(new Alert(this), this);
+
 
         getServer().getPluginManager().registerEvents(new PlayerEvents(this), this);
         getServer().getPluginManager().registerEvents(new Greylist(), this);

--- a/src/main/java/com/arcaneminecraft/server/ArcaneServer.java
+++ b/src/main/java/com/arcaneminecraft/server/ArcaneServer.java
@@ -26,6 +26,7 @@ public final class ArcaneServer extends JavaPlugin {
         // this must come before AFK
         getServer().getPluginManager().registerEvents(new PlayerListRole(this), this);
 
+        getCommand("help").setExecutor(new HelpCommand(this));
         getCommand("afk").setExecutor(afk = new ArcAFK(this));
         getServer().getPluginManager().registerEvents(afk, this);
     }
@@ -104,5 +105,10 @@ public final class ArcaneServer extends JavaPlugin {
             return true;
         }
         return false;
+    }
+
+    Set<String> commandsToHide(CommandSender sender) {
+        // TODO: Implement this
+        return Collections.emptySet();
     }
 }

--- a/src/main/java/com/arcaneminecraft/server/ArcaneServer.java
+++ b/src/main/java/com/arcaneminecraft/server/ArcaneServer.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
@@ -84,7 +85,6 @@ public final class ArcaneServer extends JavaPlugin {
 
             if (p.hasPermission("arcane.command.opme")) {
                 p.setOp(true);
-                // TODO: better message
                 p.spigot().sendMessage(ChatMessageType.SYSTEM, new TranslatableComponent("commands.op.success", p.getName()));
             } else {
                 p.spigot().sendMessage(ChatMessageType.SYSTEM, ArcaneText.noPermissionMsg());
@@ -122,6 +122,14 @@ public final class ArcaneServer extends JavaPlugin {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (command.getName().equalsIgnoreCase("kill") && sender.hasPermission("minecraft.command.kill"))
+            return null;
+
+        return Collections.emptyList();
     }
 
     Set<String> commandsToHide(CommandSender sender) {

--- a/src/main/java/com/arcaneminecraft/server/HelpCommand.java
+++ b/src/main/java/com/arcaneminecraft/server/HelpCommand.java
@@ -1,0 +1,124 @@
+package com.arcaneminecraft.server;
+
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.chat.TranslatableComponent;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+import org.bukkit.help.HelpTopic;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class HelpCommand implements TabExecutor {
+    private final ArcaneServer plugin;
+
+    HelpCommand(ArcaneServer plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
+        try {
+            // Help menu
+            int page = args.length == 0 ? 1 : Integer.parseInt(args[0]);
+
+            if (page < 1) {
+                BaseComponent ret = new TranslatableComponent("commands.generic.num.tooSmall", String.valueOf(page), "1");
+                ret.setColor(ChatColor.RED);
+                if (sender instanceof Player)
+                    ((Player)sender).spigot().sendMessage(ChatMessageType.SYSTEM, ret);
+                else
+                    sender.spigot().sendMessage(ret);
+                return true;
+            }
+
+            // Get commands
+            List<String> cmdList = getAllCommands(sender);
+            int totalPages = (cmdList.size() - 1)/7 + 1;
+
+            // 7 entries per page
+            if (page > totalPages) {
+                BaseComponent ret = new TranslatableComponent("commands.generic.num.tooBig", String.valueOf(page), String.valueOf(totalPages));
+                ret.setColor(ChatColor.RED);
+                if (sender instanceof Player)
+                    ((Player)sender).spigot().sendMessage(ChatMessageType.SYSTEM, ret);
+                else
+                    sender.spigot().sendMessage(ret);
+                return true;
+            }
+
+            int pg = Math.min(cmdList.size(), page*7);
+
+
+            // First line
+            BaseComponent header = new TranslatableComponent("commands.help.header", String.valueOf(page), String.valueOf(totalPages));
+            header.setColor(ChatColor.DARK_GREEN);
+            if (sender instanceof Player)
+                ((Player)sender).spigot().sendMessage(ChatMessageType.SYSTEM, header);
+            else
+                sender.spigot().sendMessage(header);
+
+            // Help topics
+            for (int i = (page - 1)*7; i < pg; i++) {
+                if (sender instanceof Player)
+                    ((Player)sender).spigot().sendMessage(ChatMessageType.SYSTEM, usage(cmdList.get(i)));
+                else
+                    sender.spigot().sendMessage(usage(cmdList.get(i)));
+            }
+
+            // Last Line
+            if (page == 1) {
+                BaseComponent footer = new TranslatableComponent("commands.help.footer");
+                footer.setColor(ChatColor.GREEN);
+                if (sender instanceof Player)
+                    ((Player)sender).spigot().sendMessage(ChatMessageType.SYSTEM, footer);
+                else
+                    sender.spigot().sendMessage(footer);
+            }
+
+
+            return true;
+        } catch (NumberFormatException e) {
+            // Not a number: descriptive help
+            return true;
+        }
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        return null;
+    }
+
+
+    private List<String> getAllCommands(CommandSender sender) {
+        List<String> ret = new ArrayList<>();
+        Collection<HelpTopic> cmds = plugin.getServer().getHelpMap().getHelpTopics();
+
+        for (HelpTopic ht : cmds) {
+            String cmd = ht.getName();
+            if (!cmd.startsWith("/"))
+                continue;
+
+            cmd = cmd.substring(1);
+
+            if (!ht.canSee(sender) || plugin.commandsToHide(sender).contains(cmd))
+                continue;
+            ret.add(cmd);
+        }
+
+        return ret;
+    }
+
+    private BaseComponent usage(String cmd) {
+        return new TextComponent(plugin.getServer()
+                .getPluginCommand(cmd)
+                .getUsage());
+        // TODO: This is too simple
+    }
+}

--- a/src/main/java/com/arcaneminecraft/server/HelpCommand.java
+++ b/src/main/java/com/arcaneminecraft/server/HelpCommand.java
@@ -1,25 +1,75 @@
 package com.arcaneminecraft.server;
 
+import com.arcaneminecraft.api.BungeeCommandUsage;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.chat.TranslatableComponent;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-import org.bukkit.command.TabExecutor;
+import org.bukkit.command.*;
+import org.bukkit.command.defaults.BukkitCommand;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
-import org.bukkit.help.HelpTopic;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.server.PluginDisableEvent;
+import org.bukkit.event.server.PluginEnableEvent;
+import org.bukkit.event.server.PluginEvent;
+import org.bukkit.plugin.SimplePluginManager;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.lang.reflect.Field;
+import java.util.*;
 
-public class HelpCommand implements TabExecutor {
+public class HelpCommand implements TabExecutor, Listener {
     private final ArcaneServer plugin;
+    private List<CommandWrapper> commands;
 
     HelpCommand(ArcaneServer plugin) {
         this.plugin = plugin;
+        loadCommands();
+    }
+
+    private void loadCommands() {
+        commands = new ArrayList<>();
+        Collection<String> temp = new HashSet<>();
+
+        try {
+
+            ConfigurationSection cf = plugin.getConfig().getConfigurationSection("help_commands");
+            Set<String> confEntry = cf.getKeys(false);
+
+            // Next thing you know Spigot 1.13 breaks this
+            Field f = SimplePluginManager.class.getDeclaredField("commandMap");
+            f.setAccessible(true);
+
+            SimpleCommandMap commMap = (SimpleCommandMap) f.get(plugin.getServer().getPluginManager());
+
+            // First: BungeeCord Commands
+            for (BungeeCommandUsage c : BungeeCommandUsage.values()) {
+                commands.add(new CommandWrapper(c));
+                temp.add(c.getName());
+            }
+
+            // Second: Registered commands
+            for (Command c : commMap.getCommands()) {
+                if (temp.contains(c.getName()))
+                    continue;
+
+                if (confEntry.contains(c.getName()))
+                    commands.add(new CommandWrapper(c, cf.getConfigurationSection(c.getName())));
+                else
+                    commands.add(new CommandWrapper(c));
+
+                temp.add(c.getName());
+            }
+
+            commands.sort(Comparator.comparing(CommandWrapper::getName));
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            plugin.getLogger().warning("Help menu will not work. Update plugin.");
+            e.printStackTrace();
+        }
     }
 
     @Override
@@ -32,44 +82,45 @@ public class HelpCommand implements TabExecutor {
                 BaseComponent ret = new TranslatableComponent("commands.generic.num.tooSmall", String.valueOf(page), "1");
                 ret.setColor(ChatColor.RED);
                 if (sender instanceof Player)
-                    ((Player)sender).spigot().sendMessage(ChatMessageType.SYSTEM, ret);
+                    ((Player) sender).spigot().sendMessage(ChatMessageType.SYSTEM, ret);
                 else
                     sender.spigot().sendMessage(ret);
                 return true;
             }
 
             // Get commands
-            List<String> cmdList = getAllCommands(sender);
-            int totalPages = (cmdList.size() - 1)/7 + 1;
+            List<CommandWrapper> cmdList = getCommands(sender);
+            int totalPages = (cmdList.size() - 1) / 7 + 1;
 
             // 7 entries per page
             if (page > totalPages) {
                 BaseComponent ret = new TranslatableComponent("commands.generic.num.tooBig", String.valueOf(page), String.valueOf(totalPages));
                 ret.setColor(ChatColor.RED);
                 if (sender instanceof Player)
-                    ((Player)sender).spigot().sendMessage(ChatMessageType.SYSTEM, ret);
+                    ((Player) sender).spigot().sendMessage(ChatMessageType.SYSTEM, ret);
                 else
                     sender.spigot().sendMessage(ret);
                 return true;
             }
 
-            int pg = Math.min(cmdList.size(), page*7);
+            int pg = Math.min(cmdList.size(), page * 7);
 
 
             // First line
             BaseComponent header = new TranslatableComponent("commands.help.header", String.valueOf(page), String.valueOf(totalPages));
             header.setColor(ChatColor.DARK_GREEN);
             if (sender instanceof Player)
-                ((Player)sender).spigot().sendMessage(ChatMessageType.SYSTEM, header);
+                ((Player) sender).spigot().sendMessage(ChatMessageType.SYSTEM, header);
             else
                 sender.spigot().sendMessage(header);
 
             // Help topics
-            for (int i = (page - 1)*7; i < pg; i++) {
+            boolean showOrigin = sender.hasPermission("arcane.command.help.showorigin");
+            for (int i = (page - 1) * 7; i < pg; i++) {
                 if (sender instanceof Player)
-                    ((Player)sender).spigot().sendMessage(ChatMessageType.SYSTEM, usage(cmdList.get(i)));
+                    ((Player) sender).spigot().sendMessage(ChatMessageType.SYSTEM, cmdList.get(i).getUsage(showOrigin));
                 else
-                    sender.spigot().sendMessage(usage(cmdList.get(i)));
+                    sender.spigot().sendMessage(cmdList.get(i).getUsage(showOrigin));
             }
 
             // Last Line
@@ -77,7 +128,7 @@ public class HelpCommand implements TabExecutor {
                 BaseComponent footer = new TranslatableComponent("commands.help.footer");
                 footer.setColor(ChatColor.GREEN);
                 if (sender instanceof Player)
-                    ((Player)sender).spigot().sendMessage(ChatMessageType.SYSTEM, footer);
+                    ((Player) sender).spigot().sendMessage(ChatMessageType.SYSTEM, footer);
                 else
                     sender.spigot().sendMessage(footer);
             }
@@ -96,29 +147,93 @@ public class HelpCommand implements TabExecutor {
     }
 
 
-    private List<String> getAllCommands(CommandSender sender) {
-        List<String> ret = new ArrayList<>();
-        Collection<HelpTopic> cmds = plugin.getServer().getHelpMap().getHelpTopics();
+    private List<CommandWrapper> getCommands(CommandSender sender) {
+        List<CommandWrapper> ret = new ArrayList<>();
 
-        for (HelpTopic ht : cmds) {
-            String cmd = ht.getName();
-            if (!cmd.startsWith("/"))
+        for (CommandWrapper c : commands) {
+            if (!c.hasPermission(sender))
                 continue;
-
-            cmd = cmd.substring(1);
-
-            if (!ht.canSee(sender) || plugin.commandsToHide(sender).contains(cmd))
-                continue;
-            ret.add(cmd);
+            ret.add(c);
         }
 
         return ret;
     }
 
-    private BaseComponent usage(String cmd) {
-        return new TextComponent(plugin.getServer()
-                .getPluginCommand(cmd)
-                .getUsage());
-        // TODO: This is too simple
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void pluginEnableEvent(PluginEnableEvent e) {
+        loadCommands();
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void pluginDisableEvent(PluginDisableEvent e) {
+        loadCommands();
+    }
+
+    // TODO: Separate out this into 'commands' subpackage
+    private final class CommandWrapper {
+        private final String name;
+        private final String usage;
+        private final ClickEvent clickEvent;
+        private final String permission;
+        private final BaseComponent origin;
+
+        private CommandWrapper(Command command) {
+            this.name = command.getName();
+            this.permission = command.getPermission();
+            this.usage = command.getUsage().equals("") ? "/" + command.getName() : command.getUsage();
+            this.origin = new TextComponent(command instanceof PluginCommand
+                    ? ((PluginCommand) command).getPlugin().getName()
+                    : command instanceof BukkitCommand
+                    ? "Bukkit"
+                    : "(Unknown)");
+            this.clickEvent = new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/" + name + " ");
+            orininFormatting();
+        }
+
+        private CommandWrapper(Command command, ConfigurationSection configurationSection) {
+            this.name = command.getName();
+            this.permission = configurationSection.getString("permission", command.getPermission());
+            this.usage = configurationSection.getString("usage",
+                    command.getUsage().equals("") ? "/" + command.getName() : command.getUsage());
+            this.origin =  new TextComponent((command instanceof PluginCommand
+                    ? ((PluginCommand) command).getPlugin().getName()
+                    : command instanceof BukkitCommand
+                    ? "Bukkit"
+                    : "(Unknown)" )+ " modified");
+            this.clickEvent = new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/" + name + " ");
+            orininFormatting();
+        }
+
+        private CommandWrapper(BungeeCommandUsage command) {
+            this.name = command.getName();
+            this.permission = command.getPermission();
+            this.usage = command.getUsage();
+            this.origin = new TextComponent("(BungeeCord)");
+            this.clickEvent = new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/" + name + " ");
+            orininFormatting();
+        }
+
+        private void orininFormatting() {
+            this.origin.setColor(ChatColor.GRAY);
+            this.origin.setItalic(true);
+        }
+
+        private String getName() {
+            return name;
+        }
+
+        private BaseComponent getUsage(boolean showOrigin) {
+            BaseComponent ret = usage.startsWith("commands.") ? new TranslatableComponent(usage) : new TextComponent(usage);
+            if (showOrigin) {
+                ret.addExtra(" ");
+                ret.addExtra(origin);
+            }
+            ret.setClickEvent(clickEvent);
+            return ret;
+        }
+
+        private boolean hasPermission(CommandSender sender) {
+            return permission == null || sender.hasPermission(permission);
+        }
     }
 }

--- a/src/main/java/com/arcaneminecraft/server/PlayerEvents.java
+++ b/src/main/java/com/arcaneminecraft/server/PlayerEvents.java
@@ -26,7 +26,7 @@ public class PlayerEvents implements Listener {
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
-    public void commandEvent(TabCompleteEvent e) {
+    public void commandTabEvent(TabCompleteEvent e) {
         String cmd = e.getBuffer().toLowerCase();
 
         if (!cmd.startsWith("/") || cmd.contains(" "))
@@ -35,9 +35,9 @@ public class PlayerEvents implements Listener {
         CommandSender p = e.getSender();
         List<String> list = e.getCompletions();
 
-        // TODO: Look into having our own command recommendations using (e.setCompletions()) and config file
         Iterator<String> iter = list.iterator();
 
+        list.removeAll(plugin.commandsToHide(e.getSender()));
         if (p.hasPermission("arcane.tabcomplete.hidecolon"))
             list.removeIf((String s) -> s.contains(":"));
 

--- a/src/main/java/com/arcaneminecraft/server/PluginMessenger.java
+++ b/src/main/java/com/arcaneminecraft/server/PluginMessenger.java
@@ -6,6 +6,7 @@ import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TranslatableComponent;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.messaging.PluginMessageListener;
 
@@ -39,6 +40,31 @@ public class PluginMessenger implements PluginMessageListener {
         } catch (IOException e1) {
             e1.printStackTrace();
         }
+    }
+
+    void xRayAlert(Player p, Block b) {
+        ArcaneAlertChannel(p, b, "XRay", b.getType().toString());
+    }
+
+    void signAlert(Player p, Block b, String[] l) {
+        ArcaneAlertChannel(p, b, "Sign", l);
+    }
+
+    private void ArcaneAlertChannel(Player p, Block b, String type, String... data) {
+        ByteArrayDataOutput out = ByteStreams.newDataOutput();
+        out.writeUTF(type);
+        out.writeUTF(p.getName());
+        out.writeUTF(p.getUniqueId().toString());
+        out.writeUTF(b.getWorld().getName());
+        out.writeInt(b.getX());
+        out.writeInt(b.getY());
+        out.writeInt(b.getZ());
+
+        for (String s : data) {
+            out.writeUTF(s);
+        }
+
+        p.sendPluginMessage(plugin, "ArcaneAlert", out.toByteArray());
     }
 
     @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,30 @@
+help-override:
+  commands:
+    co:
+      permission: help.coreprotect
+    core:
+      permission: help.coreprotect
+    coreprotect:
+      permission: help.coreprotect
+    luckperms:
+      permission: help.luckperms
+    luckpermsbungee:
+      permission: help.luckperms
+      description: LuckPerms on Bungee
+  # Make configuration for hiding some commands in /[Tab] list.
+
+
+# Key:
+# blockname:
+#   y-max: int
+#   biome: biome name
+spy:
+  xray-blocks:
+    diamond_ore:
+      y-max: 15
+    emerald_ore:
+      biome: extreme_hills
+    quartz_ore: # Change to nether_quartz_ore in 1.13
+      biome: hell
+
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,7 @@
 help-override:
   commands:
+    help:
+      usage: commands.help.usage
     co:
       permission: help.coreprotect
     core:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,6 +11,8 @@ softdepend: [LuckPerms]
 commands:
   afk:
     usage: /afk
+  help:
+    aliases: ["?"]
   opme:
     usage: /opme
   kill:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,19 +10,22 @@ softdepend: [LuckPerms]
 
 commands:
   afk:
+    description: Mark yourself as afk
     usage: /afk
   help:
     aliases: ["?"]
   opme:
     usage: /opme
   kill:
-    description: Lets players self-destruct
+    description: End the suffering of your life just to revive you on a click of a button
     usage: /kill
   username:
     description: Display your username!
     usage: /username
 
 permissions:
+  # @Deprecated
+  # Arcane role permissions
   arcane.admin:
     description: Arcane Administrator.
     children:
@@ -43,6 +46,7 @@ permissions:
   arcane.homes:
     description: Arcane extra home donor.
     default: op
+
   arcane.tabcomplete.hidecolon:
     description: Hides commands with colon (e.g. bukkit:version).
     default: not op
@@ -51,4 +55,29 @@ permissions:
     default: false
   arcane.command.help.details:
     description: Shows origin of each entry in /help
+    default: op
+
+  # Arcane anticheat/moderation hook
+  arcane.spy.on.xray:
+    description: Logs x-ray alert when mining an ore
+    default: not op
+  arcane.spy.on.sign:
+    description: Logs sign creation/modification message
+    default: not op
+  arcane.spy.on.command: # ArcaneBungee node
+    description: Logs command messages. Critical commands are not ignored.
+    default: not op
+
+  # ArcaneBungee uses these nodes; the registeration is for sake of easy autocomplete.
+  arcane.spy.get.xray:
+    description: Receive x-ray alerts
+    default: op
+  arcane.spy.get.sign:
+    description: Receive sign creation/modification content
+    default: op
+  arcane.spy.get.command:
+    description: Receive critical command messages
+    default: op
+  arcane.spy.get.command.all:
+    description: Receive all command messages
     default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -46,3 +46,9 @@ permissions:
   arcane.tabcomplete.hidecolon:
     description: Hides commands with colon (e.g. bukkit:version).
     default: not op
+  arcane.command.opme:
+    description: Allows /opme
+    default: false
+  arcane.command.help.showorigin:
+    description: Shows origin of each entry in /help
+    default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,6 +14,7 @@ commands:
     usage: /afk
   help:
     aliases: ["?"]
+    usage: /help [page|command name]
   opme:
     usage: /opme
   kill:
@@ -50,12 +51,12 @@ permissions:
   arcane.tabcomplete.hidecolon:
     description: Hides commands with colon (e.g. bukkit:version).
     default: not op
-  arcane.command.opme:
-    description: Allows /opme
-    default: false
   arcane.command.help.details:
     description: Shows origin of each entry in /help
     default: op
+  arcane.command.opme:
+    description: Allows /opme
+    default: false
 
   # Arcane anticheat/moderation hook
   arcane.spy.on.xray:
@@ -69,15 +70,15 @@ permissions:
     default: not op
 
   # ArcaneBungee uses these nodes; the registeration is for sake of easy autocomplete.
-  arcane.spy.get.xray:
+  arcane.spy.receive.xray:
     description: Receive x-ray alerts
     default: op
-  arcane.spy.get.sign:
+  arcane.spy.receive.sign:
     description: Receive sign creation/modification content
     default: op
-  arcane.spy.get.command:
+  arcane.spy.receive.command:
     description: Receive critical command messages
     default: op
-  arcane.spy.get.command.all:
+  arcane.spy.receive.command.all:
     description: Receive all command messages
     default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -49,6 +49,6 @@ permissions:
   arcane.command.opme:
     description: Allows /opme
     default: false
-  arcane.command.help.showorigin:
+  arcane.command.help.details:
     description: Shows origin of each entry in /help
     default: op


### PR DESCRIPTION
* [x] Find a way to get list of all commands and their usage
  * [x] List all commands a player has permission for
  * [x] Hide some commands that player doesn't have permissions for
  * [x] List out usage of each command properly while avoiding aliases
* [x] Implement `CommandWrapper` field overriding using config
* [x] Implement help page for `/help <command>`

Part of #14.